### PR TITLE
dependencies: add initial dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pybind11
+nmslib @ git+https://github.com/nmslib/nmslib.git#egg=nmslib&subdirectory=python_bindings
+pyserini
+faiss-cpu
+torch
+torchvision
+torchaudio


### PR DESCRIPTION
Added the following dependencies to the requirements.txt file:
- pybind11
- nmslib from GitHub repository
- pyserini
- faiss-cpu
- torch
- torchvision
- torchaudio