### PR TITLE
fix: update release-drafter labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -42,6 +42,9 @@ autolabeler:
   - label: feature
     branch:
       - '/^feat(ure)?[/-].+/'
+  - label: enhancement
+    branch:
+      - '/(enhancement|improve)[/-].+/'
   - label: fix
     branch:
       - '/^fix[/-].+/'
@@ -59,12 +62,12 @@ autolabeler:
       - '/(refactor|refactoring)[/-].+/'
   - label: documentation
     branch:
-      - '/doc(umentation)[/-].+/'
+      - '/^doc(umentation)[/-].+/'
     files:
       - '*.md'
-  - label: release
+  - label: dependencies
     branch:
-      - '/release[/-].+/'
-  - label: enhancement
+      - '/^dep(endencies)[/-].+/'
+  - label: others
     branch:
-      - '/(enhancement|improve)[/-].+/'
+      - '/^others[/-].+/'


### PR DESCRIPTION
- Added 'enhancement' label for branches matching '/(enhancement|improve)[/-].+/'
- Updated 'documentation' label to match '/^doc(umentation)[/-].+/'
- Changed 'release' label to 'dependencies' for branches matching '/^dep(endencies)[/-].+/'
- Added 'others' label for branches matching '/^others[/-].+/'