### PR TITLE
feat: add black and isort configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ python = "^3.10,<3.11"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 79
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
Added configurations for black and isort in pyproject.toml:
- Set line-length to 79 for black.
- Set profile to "black" for isort.