### PR TITLE
fix(requirements): correct version specifiers for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --index-url https://download.pytorch.org/whl/cu121
 torch==2.3.1
-torchvision=0.18.1
-torchaudio=2.3.1
+torchvision==0.18.1
+torchaudio==2.3.1
 
 pybind11
 nmslib @ git+https://github.com/nmslib/nmslib.git#egg=nmslib&subdirectory=python_bindings


### PR DESCRIPTION
Corrected the version specifiers for torchvision and torchaudio in the requirements.txt file to use '==' instead of '='. This ensures proper version matching and avoids potential installation issues.